### PR TITLE
Remove empty options

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ classifiers are generated based on:
      Programming Language :: Python :: 3.6
 ```
 
+### removes empty options in any section
+
+```diff
+ [options]
+-dependency_links =
+ python_requires = >= 3.6.1
+```
+
 ## related projects
 
 - [setup-py-upgrade]: automatically migrate `setup.py` -> `setup.cfg`

--- a/setup_cfg_fmt.py
+++ b/setup_cfg_fmt.py
@@ -323,6 +323,7 @@ def format_file(
 
     cfg = configparser.ConfigParser()
     cfg.read_string(contents)
+    _clean_sections(cfg)
 
     # normalize names to underscores so sdist / wheel have the same prefix
     cfg['metadata']['name'] = cfg['metadata']['name'].replace('-', '_')
@@ -417,6 +418,16 @@ def format_file(
             f.write(new_contents)
 
     return new_contents != contents
+
+
+def _clean_sections(cfg: configparser.ConfigParser) -> None:
+    """Removes any empty options and sections."""
+    for section in cfg.sections():
+        new_options = {k: v for k, v in cfg[section].items() if v}
+        if new_options:
+            cfg[section] = new_options
+        else:
+            cfg.pop(section)
 
 
 def _ver_type(s: str) -> Tuple[int, int]:

--- a/tests/setup_cfg_fmt_test.py
+++ b/tests/setup_cfg_fmt_test.py
@@ -353,6 +353,46 @@ def test_python_requires_left_alone(tmpdir, s):
     )
 
 
+@pytest.mark.parametrize(
+    ('section', 'expected'),
+    (
+        pytest.param(
+            '\n'
+            '[options]\n'
+            'dependency_links = \n'
+            'py_modules = pkg\n',
+            '\n'
+            '[options]\n'
+            'py_modules = pkg\n',
+            id='only empty options removed',
+        ),
+        pytest.param(
+            '\n'
+            '[options]\n'
+            'dependency_links = \n',
+            '',
+            id='entire section removed if all empty options are removed',
+        ),
+    ),
+)
+def test_strips_empty_options_and_sections(tmpdir, section, expected):
+    setup_cfg = tmpdir.join('setup.cfg')
+    setup_cfg.write(
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n'
+        f'{section}',
+    )
+
+    main((str(setup_cfg),))
+    assert setup_cfg.read() == (
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n'
+        f'{expected}'
+    )
+
+
 def test_guess_python_requires_python2_tox_ini(tmpdir):
     tmpdir.join('tox.ini').write('[tox]\nenvlist=py36,py27,py37,pypy\n')
     setup_cfg = tmpdir.join('setup.cfg')


### PR DESCRIPTION
Saw some repos had `dependency_links =` in their config; this change automates removing it.