### PR TITLE
Add support for VCS requirements

### DIFF
--- a/setup_cfg_fmt.py
+++ b/setup_cfg_fmt.py
@@ -224,8 +224,8 @@ def _normalize_req(req: str) -> str:
     return f'{normalized};{envs}'
 
 
-BASE_NAME_REGEX = re.compile(r'[^!=><\s]+')
-REQ_REGEX = re.compile(r'(===|==|!=|~=|>=?|<=?)\s*([^,]+)')
+BASE_NAME_REGEX = re.compile(r'[^!=><\s@]+')
+REQ_REGEX = re.compile(r'(===|==|!=|~=|>=?|<=?|@)\s*([^,]+)')
 
 
 def _normalize_lib(lib: str) -> str:

--- a/tests/setup_cfg_fmt_test.py
+++ b/tests/setup_cfg_fmt_test.py
@@ -77,7 +77,9 @@ def test_noop(tmpdir):
             '    req11; python_version=="2.7"\n'
             '    req08    ==    2\n'
             '    req12;\n'
-            '    req04 >= 1\n',
+            '    req04 >= 1\n'
+            '    req15 @ git+https://github.com/foo/bar.git@master\n'
+            '    req16@git+https://github.com/biz/womp.git@tag\n',
 
             '[metadata]\n'
             'name = pkg\n'
@@ -97,6 +99,8 @@ def test_noop(tmpdir):
             '    req12\n'
             '    req13!=2,>=7\n'
             '    req14>=1,<=2\n'
+            '    req15@git+https://github.com/foo/bar.git@master\n'
+            '    req16@git+https://github.com/biz/womp.git@tag\n'
             '    req06;python_version==2.7\n'
             '    req07;os_version!=windows\n'
             '    req11;python_version=="2.7"\n',


### PR DESCRIPTION
Right now, if you have a VCS requirement, like

```
install_requires =
    dask-jobqueue@git+https://github.com/dask/dask-jobqueue.git@master
```

it gets truncated to

```
install_requires =
    dask-jobqueue
```

This PR adds a special early-returning case (since `@` is exclusive with the normal version specifier syntax, as far as I know) to `_normalize_lib` that preserves such requirements. It makes the spacing around the first `@` match `pip install` displays, which is `dask-jobqueue@ git+...` (no space before, yes space after). No other formatting is done to whatever comes after the `@`.