### PR TITLE
Keep author and maintainer information together

### DIFF
--- a/setup_cfg_fmt.py
+++ b/setup_cfg_fmt.py
@@ -20,8 +20,10 @@ KEYS_ORDER: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
         'metadata', (
             'name', 'version', 'description',
             'long_description', 'long_description_content_type',
-            'url', 'author', 'author_email', 'license', 'license_file',
-            'license_files', 'platforms', 'classifiers',
+            'url',
+            'author', 'author_email', 'maintainer', 'maintainer_email',
+            'license', 'license_file', 'license_files',
+            'platforms', 'classifiers',
         ),
     ),
     (

--- a/tests/setup_cfg_fmt_test.py
+++ b/tests/setup_cfg_fmt_test.py
@@ -168,6 +168,25 @@ def test_rewrite_requires(which, input_tpl, expected_tpl, tmpdir):
 
             id='sorts classifiers',
         ),
+        pytest.param(
+            '[metadata]\n'
+            'maintainer_email = jane@example.com\n'
+            'maintainer = jane\n'
+            'license = foo\n'
+            'name = pkg\n'
+            'author_email = john@example.com\n'
+            'author = john\n',
+
+            '[metadata]\n'
+            'name = pkg\n'
+            'author = john\n'
+            'author_email = john@example.com\n'
+            'maintainer = jane\n'
+            'maintainer_email = jane@example.com\n'
+            'license = foo\n',
+
+            id='orders authors and maintainers',
+        ),
     ),
 )
 def test_rewrite(input_s, expected, tmpdir):


### PR DESCRIPTION
Resolves #37 by sorting maintainer information immediately after author information.

There was no existing test for the sort order - let me know if you want that as part of this PR.