### PR TITLE
Default to rewriting setup.cfg without args

### DIFF
--- a/setup_cfg_fmt.py
+++ b/setup_cfg_fmt.py
@@ -492,7 +492,7 @@ def _ver_type(s: str) -> Version:
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('filenames', nargs='*')
+    parser.add_argument('filenames', nargs='*', default=['setup.cfg'])
     parser.add_argument('--min-py3-version', type=_ver_type, default=(3, 6))
     parser.add_argument('--max-py-version', type=_ver_type, default=(3, 9))
     args = parser.parse_args(argv)


### PR DESCRIPTION
Currently, running setup-cfg-fmt without any arguments silently does nothing, which can be confusing.

An alternative solution would probably be to set nargs='+' so that at least one filename is required, but I think defaulting to setup.cfg is a safe bet.

Also, thanks for the useful tool! :+1: