### PR TITLE
Adjust default for --max-py-version to 3.10

### DIFF
--- a/setup_cfg_fmt.py
+++ b/setup_cfg_fmt.py
@@ -494,7 +494,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     parser.add_argument('--min-py3-version', type=_ver_type, default=(3, 6))
-    parser.add_argument('--max-py-version', type=_ver_type, default=(3, 9))
+    parser.add_argument('--max-py-version', type=_ver_type, default=(3, 10))
     args = parser.parse_args(argv)
 
     retv = 0


### PR DESCRIPTION
Noticed this while working on https://github.com/pytest-dev/pytest/pull/8494, however I'm not sure you want to change defaults given 3.10 is not out yet.