### PR TITLE
use license_files instead of the deprecated license_file

### DIFF
--- a/setup_cfg_fmt.py
+++ b/setup_cfg_fmt.py
@@ -386,7 +386,7 @@ def format_file(
     # set license fields if a license exists
     license_filename = _first_file(filename, 'licen[sc]e')
     if license_filename is not None:
-        cfg['metadata']['license_file'] = os.path.basename(license_filename)
+        cfg['metadata']['license_files'] = os.path.basename(license_filename)
 
         license_id = identify.license_id(license_filename)
         if license_id is not None:

--- a/tests/setup_cfg_fmt_test.py
+++ b/tests/setup_cfg_fmt_test.py
@@ -332,7 +332,7 @@ def test_sets_license_file_if_license_exists(filename, tmpdir):
         f'[metadata]\n'
         f'name = pkg\n'
         f'version = 1.0\n'
-        f'license_file = {filename}\n'
+        f'license_files = {filename}\n'
     )
 
 
@@ -360,7 +360,7 @@ def test_rewrite_sets_license_type_and_classifier(tmpdir):
         'name = pkg\n'
         'version = 1.0\n'
         'license = MIT\n'
-        'license_file = LICENSE\n'
+        'license_files = LICENSE\n'
         'classifiers =\n'
         '    License :: OSI Approved :: MIT License\n'
     )
@@ -403,7 +403,7 @@ freely, subject to the following restrictions:
         'name = pkg\n'
         'version = 1.0\n'
         'license = Zlib\n'
-        'license_file = LICENSE\n'
+        'license_files = LICENSE\n'
         'classifiers =\n'
         '    License :: OSI Approved :: zlib/libpng License\n'
     )


### PR DESCRIPTION
Per https://github.com/pypa/setuptools/pull/2620, `license_file` is deprecated in favor of `license_files`. Today it spams a warning when used.