### PR TITLE
do not prefer asciidoctor for long_description

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ setuptools allows dashed names but does not document them.
 +long_description = file: README.md
 ```
 
-### adds `long_description` if `README.md` is present
+### adds `long_description` if `README` is present
 
 This will show up on the pypi project page
 

--- a/setup_cfg_fmt.py
+++ b/setup_cfg_fmt.py
@@ -103,7 +103,13 @@ def _case_insensitive_glob(s: str) -> str:
 def _first_file(setup_cfg: str, prefix: str) -> str | None:
     prefix = _case_insensitive_glob(prefix)
     path = _adjacent_filename(setup_cfg, prefix)
-    for filename in sorted(glob.iglob(f'{path}*')):
+
+    # prefer non-asciidoc because pypi does not render it
+    # https://github.com/asottile/setup-cfg-fmt/issues/149
+    def sort_key(filename: str) -> tuple[bool, str]:
+        return (filename.endswith(('.adoc', '.asciidoc')), filename)
+
+    for filename in sorted(glob.iglob(f'{path}*'), key=sort_key):
         if os.path.isfile(filename):
             return filename
     else:
@@ -369,7 +375,7 @@ def format_file(
     # normalize names to underscores so sdist / wheel have the same prefix
     cfg['metadata']['name'] = cfg['metadata']['name'].replace('-', '_')
 
-    # if README.md exists, set `long_description` + content type
+    # if README exists, set `long_description` + content type
     readme = _first_file(filename, 'readme')
     if readme is not None:
         long_description = f'file: {os.path.basename(readme)}'

--- a/tests/setup_cfg_fmt_test.py
+++ b/tests/setup_cfg_fmt_test.py
@@ -296,6 +296,68 @@ def test_adds_long_description_with_readme(filename, content_type, tmpdir):
     )
 
 
+@pytest.mark.parametrize(
+    ('filename', 'content_type'),
+    (
+        ('README.rst', 'text/x-rst'),
+        ('README.markdown', 'text/markdown'),
+        ('README.md', 'text/markdown'),
+        ('README', 'text/plain'),
+        ('README.txt', 'text/plain'),
+        ('readme.txt', 'text/plain'),
+    ),
+)
+def test_readme_discover_does_not_prefer_adoc(filename, content_type, tmpdir):
+    tmpdir.join(filename).write('my project!')
+    tmpdir.join('README.adoc').write('my project!')
+    tmpdir.join('README.asciidoc').write('my project!')
+
+    setup_cfg = tmpdir.join('setup.cfg')
+    setup_cfg.write(
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n',
+    )
+
+    assert main((str(setup_cfg),))
+
+    assert setup_cfg.read() == (
+        f'[metadata]\n'
+        f'name = pkg\n'
+        f'version = 1.0\n'
+        f'long_description = file: {filename}\n'
+        f'long_description_content_type = {content_type}\n'
+    )
+
+
+@pytest.mark.parametrize(
+    'filename',
+    (
+        'README.adoc',
+        'README.asciidoc',
+    ),
+)
+def test_readme_discover_uses_asciidoc_if_none_other_found(filename, tmpdir):
+    tmpdir.join(filename).write('my project!')
+
+    setup_cfg = tmpdir.join('setup.cfg')
+    setup_cfg.write(
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n',
+    )
+
+    assert main((str(setup_cfg),))
+
+    assert setup_cfg.read() == (
+        f'[metadata]\n'
+        f'name = pkg\n'
+        f'version = 1.0\n'
+        f'long_description = file: {filename}\n'
+        f'long_description_content_type = text/plain\n'
+    )
+
+
 def test_readme_discover_prefers_file_over_directory(tmpdir):
     tmpdir.join('README').mkdir()
     tmpdir.join('README.md').write('my project!')


### PR DESCRIPTION
Fixes #149

instead of *ignoring* asciidoctor files alltogether, i decided to change the new algo to *not prefer* it.
added tests to reflect that too.

because the current behaviour results in error when building wheel as per linked issue this pr is equivalent to a patch