### PR TITLE
Rename license_file to license_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,26 @@ This will show up on the pypi project page
 +long_description_content_type = text/markdown
 ```
 
-### adds `license_file` / `license` / license classifier if `LICENSE` exists
+### rewrites `license_file` to `license_files`
+
+This deals with the deprecation of `license_file` [in setuptools 56](https://setuptools.pypa.io/en/latest/history.html#v56-0-0).
+
+```diff
+ [metadata]
+ name = pre_commit
+ version = 1.14.5
+-license_file = LICENSE
++license_files = LICENSE
+```
+
+### adds `license_files` / `license` / license classifier if `LICENSE` exists
 
 ```diff
  [metadata]
  name = pre_commit
  version = 1.14.5
 +license = MIT
-+license_file = LICENSE
++license_files = LICENSE
 +classifiers =
 +    License :: OSI Approved :: MIT License
 ```

--- a/setup_cfg_fmt.py
+++ b/setup_cfg_fmt.py
@@ -395,10 +395,15 @@ def format_file(
         else:
             cfg['metadata']['long_description_content_type'] = 'text/plain'
 
+    # rename license_file to license_files to handle setuptools 56 deprecation
+    if 'license_file' in cfg['metadata']:
+        cfg['metadata']['license_files'] = cfg['metadata']['license_file']
+        del cfg['metadata']['license_file']
+
     # set license fields if a license exists
     license_filename = _first_file(filename, 'licen[sc]e')
     if license_filename is not None:
-        cfg['metadata']['license_file'] = os.path.basename(license_filename)
+        cfg['metadata']['license_files'] = os.path.basename(license_filename)
 
         license_id = identify.license_id(license_filename)
         if license_id is not None:

--- a/tests/setup_cfg_fmt_test.py
+++ b/tests/setup_cfg_fmt_test.py
@@ -376,6 +376,26 @@ def test_readme_discover_prefers_file_over_directory(tmpdir):
     )
 
 
+def test_renames_license_file_to_license_files(tmpdir):
+    tmpdir.join('special-license.txt').write('COPYRIGHT (C) 2019 ME')
+    setup_cfg = tmpdir.join('setup.cfg')
+    setup_cfg.write(
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n'
+        'license_file = special-license.txt\n',
+    )
+
+    assert main((str(setup_cfg),))
+
+    assert setup_cfg.read() == (
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n'
+        'license_files = special-license.txt\n'
+    )
+
+
 @pytest.mark.parametrize(
     'filename', ('LICENSE', 'LICENCE', 'LICENSE.md', 'license.txt'),
 )
@@ -394,7 +414,7 @@ def test_sets_license_file_if_license_exists(filename, tmpdir):
         f'[metadata]\n'
         f'name = pkg\n'
         f'version = 1.0\n'
-        f'license_file = {filename}\n'
+        f'license_files = {filename}\n'
     )
 
 
@@ -422,7 +442,7 @@ def test_rewrite_sets_license_type_and_classifier(tmpdir):
         'name = pkg\n'
         'version = 1.0\n'
         'license = MIT\n'
-        'license_file = LICENSE\n'
+        'license_files = LICENSE\n'
         'classifiers =\n'
         '    License :: OSI Approved :: MIT License\n'
     )
@@ -465,7 +485,7 @@ freely, subject to the following restrictions:
         'name = pkg\n'
         'version = 1.0\n'
         'license = Zlib\n'
-        'license_file = LICENSE\n'
+        'license_files = LICENSE\n'
         'classifiers =\n'
         '    License :: OSI Approved :: zlib/libpng License\n'
     )


### PR DESCRIPTION
Deal with this deprecation warning [from setuptools 56+](https://setuptools.pypa.io/en/latest/history.html#v56-0-0) that appears whenever installing a package with `license_file`:

```
/.../tox/.tox/.package/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508:
  SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use
  license_files instead. warnings.warn(msg, warning_class)
```

As I initially aimed to fix for tox: https://github.com/tox-dev/tox/pull/2488 .
