### PR TITLE
gracefully leave license_files when used

### DIFF
--- a/setup_cfg_fmt.py
+++ b/setup_cfg_fmt.py
@@ -398,7 +398,12 @@ def format_file(
     # set license fields if a license exists
     license_filename = _first_file(filename, 'licen[sc]e')
     if license_filename is not None:
-        cfg['metadata']['license_file'] = os.path.basename(license_filename)
+        license_basename = os.path.basename(license_filename)
+        known_license_files = (
+            cfg['metadata'].get('license_files', '').strip().splitlines()
+        )
+        if license_basename not in known_license_files:
+            cfg['metadata']['license_file'] = license_basename
 
         license_id = identify.license_id(license_filename)
         if license_id is not None:

--- a/tests/setup_cfg_fmt_test.py
+++ b/tests/setup_cfg_fmt_test.py
@@ -403,6 +403,47 @@ def test_license_does_not_match_directories(tmpdir):
     test_sets_license_file_if_license_exists('LICENSE', tmpdir)
 
 
+def test_license_does_not_set_when_licenses_matches(tmpdir):
+    tmpdir.join('LICENSE').write('COPYRIGHT (C) 2019 ME')
+    setup_cfg = tmpdir.join('setup.cfg')
+    setup_cfg.write(
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n'
+        'license_files = LICENSE\n',
+    )
+
+    assert not main((str(setup_cfg),))
+
+    assert setup_cfg.read() == (
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n'
+        'license_files = LICENSE\n'
+    )
+
+
+def test_license_does_set_when_licenses_mismatches(tmpdir):
+    tmpdir.join('LICENSE').write('COPYRIGHT (C) 2019 ME')
+    setup_cfg = tmpdir.join('setup.cfg')
+    setup_cfg.write(
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n'
+        'license_files = LICENSES\n',
+    )
+
+    assert main((str(setup_cfg),))
+
+    assert setup_cfg.read() == (
+        '[metadata]\n'
+        'name = pkg\n'
+        'version = 1.0\n'
+        'license_file = LICENSE\n'
+        'license_files = LICENSES\n'
+    )
+
+
 def test_rewrite_sets_license_type_and_classifier(tmpdir):
     here = os.path.dirname(__file__)
     license_file = os.path.join(here, os.pardir, 'LICENSE')


### PR DESCRIPTION
modern setuptools deprecates license_file in favour of license_files

this change supports the initial migration
 a followup for a opt in for the change is needed

my check for the content of license-files is not yet correct, is there a configparser api to get a split up list or should i do a safe split manually