### PR TITLE
docs: update README for 3.8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ A few sources are searched for guessing `python_requires`:
 - the existing `python_requires` setting itself
 - `envlist` in `tox.ini` if present
 - python version `classifiers` that are already set
-- the `--min-py-version` argument (currently defaulting to `3.7`)
+- the `--min-py-version` argument
 
 ### adds python version classifiers
 


### PR DESCRIPTION
I noticed that something was adding 3.8+, I guessed it might be setup-cfg-fmt, so I checked the README, and it claimed the default is still 3.7+. I was able to find #208, so it was setup-cfg-fmt, the README was just not updated there too. In this PR I touched up the readme's mentions to be consistent with the current behavior.