### PR TITLE
fix --min-py-version default in readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ A few sources are searched for guessing `python_requires`:
 - the existing `python_requires` setting itself
 - `envlist` in `tox.ini` if present
 - python version `classifiers` that are already set
-- the `--min-py-version` argument (currently defaulting to `3.7`)
+- the `--min-py-version` argument (currently defaulting to `3.8`)
 
 ### adds python version classifiers
 


### PR DESCRIPTION
I came across this when I was wondering why it changed my `python_requires` in a pre-commit.ci autoupdate.