### PR TITLE
docs: explain default of `--min-py-version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ A few sources are searched for guessing `python_requires`:
 - the existing `python_requires` setting itself
 - `envlist` in `tox.ini` if present
 - python version `classifiers` that are already set
-- the `--min-py-version` argument
+- the `--min-py-version` argument (defaults to the oldest, not EOL version)
 
 ### adds python version classifiers
 


### PR DESCRIPTION
After our earlier discussion on #230 I now understood why the default is that way and why it makes sense to update it.

To avoid this problem in the future, I suggest to add a explanation to the README about the default behavior.

I hope this matches the conses reached on #207, where the mention of the specific default version was removed to reduce maintenance burdon